### PR TITLE
Use Binance WebSocket price with REST fallback

### DIFF
--- a/src/app/api/markets/route.ts
+++ b/src/app/api/markets/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { POLYMARKET_API, BINANCE_REST } from "@/lib/constants";
 import { processMarket, isBtcPriceMarket } from "@/lib/polymarket";
 import type { DashboardData } from "@/lib/types";
+import { getLatestWsPrice, initBinanceWs } from "@/lib/binanceWs";
 
 export const dynamic = "force-dynamic";
 
@@ -22,7 +23,11 @@ interface PolymarketEvent {
 
 export async function GET() {
   try {
-    // Fetch events (contains nested markets) and BTC price in parallel
+    // Ensure Binance WebSocket client is running (no-op if already started)
+    initBinanceWs();
+
+    // Fetch events (contains nested markets). Prefer WebSocket BTC price but
+    // fall back to REST if no WebSocket price is available yet.
     const [eventsRes, binanceRes] = await Promise.all([
       fetch(
         `${POLYMARKET_API.replace("/markets", "/events")}?limit=300&active=true&closed=false`,
@@ -45,7 +50,11 @@ export async function GET() {
       binanceRes.json(),
     ]);
 
-    const btcPrice = parseFloat(binanceData.price);
+    const wsPrice = getLatestWsPrice();
+    const btcPrice =
+      typeof wsPrice === "number" && !Number.isNaN(wsPrice)
+        ? wsPrice
+        : parseFloat(binanceData.price);
 
     // Extract all markets from events, filter for BTC price predictions
     const allMarkets: Array<{

--- a/src/lib/binanceWs.ts
+++ b/src/lib/binanceWs.ts
@@ -1,18 +1,67 @@
-// Binance WebSocket client for BTCUSDT ticker
-// TODO: implement connection, reconnection, and latest price caching.
+// Binance WebSocket client for BTCUSDT ticker.
+// Keeps the latest ticker price in memory and exposes it to the API layer.
+
+import { BINANCE_WS } from "@/lib/constants";
 
 export type BinanceTicker = {
   c: string; // last price as string
 };
 
 let latestPrice: number | null = null;
+let socket: WebSocket | null = null;
+let isConnecting = false;
+let hasInitialized = false;
 
 export function getLatestWsPrice(): number | null {
   return latestPrice;
 }
 
-// initBinanceWs will be implemented next: it will connect to
-// wss://stream.binance.com:9443/ws/btcusdt@ticker and update latestPrice.
+// Initialize the Binance WebSocket connection.
+// Safe to call multiple times; only the first call will actually connect.
 export function initBinanceWs(): void {
-  // placeholder for upcoming implementation
+  if (hasInitialized || isConnecting || socket) return;
+  hasInitialized = true;
+  isConnecting = true;
+
+  const connect = () => {
+    try {
+      socket = new WebSocket(BINANCE_WS);
+
+      socket.onopen = () => {
+        isConnecting = false;
+      };
+
+      socket.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data.toString()) as Partial<BinanceTicker>;
+          if (data && typeof data.c === "string") {
+            const parsed = parseFloat(data.c);
+            if (!Number.isNaN(parsed)) {
+              latestPrice = parsed;
+            }
+          }
+        } catch {
+          // Ignore malformed messages
+        }
+      };
+
+      socket.onclose = () => {
+        socket = null;
+        // Attempt a simple reconnect after a short delay
+        setTimeout(() => {
+          isConnecting = true;
+          connect();
+        }, 3_000);
+      };
+
+      socket.onerror = () => {
+        // Errors will eventually trigger onclose; nothing special to do here.
+      };
+    } catch {
+      socket = null;
+      isConnecting = false;
+    }
+  };
+
+  connect();
 }

--- a/src/lib/binanceWs.ts
+++ b/src/lib/binanceWs.ts
@@ -1,0 +1,18 @@
+// Binance WebSocket client for BTCUSDT ticker
+// TODO: implement connection, reconnection, and latest price caching.
+
+export type BinanceTicker = {
+  c: string; // last price as string
+};
+
+let latestPrice: number | null = null;
+
+export function getLatestWsPrice(): number | null {
+  return latestPrice;
+}
+
+// initBinanceWs will be implemented next: it will connect to
+// wss://stream.binance.com:9443/ws/btcusdt@ticker and update latestPrice.
+export function initBinanceWs(): void {
+  // placeholder for upcoming implementation
+}


### PR DESCRIPTION
## Summary

This PR implements a Binance WebSocket client for the BTCUSDT ticker and wires it into the  route so the dashboard can use a real-time BTC price while retaining the existing REST polling as a safe fallback.

## Changes

- Add :
  - Connects to .
  - Parses incoming messages and keeps the latest price () in memory.
  - Exposes  for the API layer.
  - Provides  which is safe to call multiple times and handles simple reconnection on close.
- Update :
  - Import  and .
  - Call  at the start of  to ensure the WS client is running.
  - Compute  by preferring the WebSocket price when available, falling back to the existing REST  price.
  - Keep the response shape and downstream processing logic unchanged.

## Rationale

- Using the WebSocket feed makes the dashboard feel more live and reduces reliance on frequent REST polling.
- Keeping the REST call as a fallback ensures the API route still works even if the WebSocket has not connected yet or temporarily fails.

## Notes

- The WebSocket client is intentionally minimal: it focuses on keeping a single latest price in memory and reconnecting after disconnects.
- There are no changes to Polymarket data fetching or the arbitrage/fair probability logic.

Closes #1.