### PR TITLE
Add equity curve / P&L simulation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import StatsBar from "@/components/StatsBar";
 import DivergenceChart from "@/components/DivergenceChart";
 import MarketList from "@/components/MarketList";
 import ExecutionLog from "@/components/ExecutionLog";
+import EquityCurveChart from "@/components/EquityCurveChart";
 import { POLL_INTERVAL_MS, MAX_CHART_POINTS, MAX_LOG_ENTRIES } from "@/lib/constants";
 import type {
   DashboardData,
@@ -12,10 +13,18 @@ import type {
   LogEntry,
   ProcessedMarket,
 } from "@/lib/types";
+import {
+  createInitialState,
+  stepEquitySimulation,
+  type EquityPoint,
+  type SimulationState,
+} from "@/lib/equityCurve";
 
 export default function Dashboard() {
   const [data, setData] = useState<DashboardData | null>(null);
   const [chartData, setChartData] = useState<DivergencePoint[]>([]);
+  const [equityData, setEquityData] = useState<EquityPoint[]>([]);
+  const [simState, setSimState] = useState<SimulationState | null>(null);
   const [logEntries, setLogEntries] = useState<LogEntry[]>([]);
   const [isLive, setIsLive] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -88,6 +97,21 @@ export default function Dashboard() {
       if (newLogs.length > 0) {
         setLogEntries((prev) => [...prev, ...newLogs].slice(-MAX_LOG_ENTRIES));
       }
+
+      // Update equity curve simulation
+      setSimState((prev) => {
+        const baseState = prev ?? createInitialState();
+        const { state: nextState, point } = stepEquitySimulation(
+          baseState,
+          dashData.markets,
+          dashData.timestamp
+        );
+        setEquityData((prevPoints) => {
+          const next = [...prevPoints, point];
+          return next.slice(-MAX_CHART_POINTS);
+        });
+        return nextState;
+      });
     } catch (err) {
       console.error("Fetch error:", err);
       setError(err instanceof Error ? err.message : "Unknown error");
@@ -120,6 +144,15 @@ export default function Dashboard() {
 
       {/* Divergence Chart */}
       <DivergenceChart data={chartData} />
+
+      {/* Equity Curve Chart */}
+      <EquityCurveChart
+        data={equityData}
+        onReset={() => {
+          setEquityData([]);
+          setSimState(null);
+        }}
+      />
 
       {/* Bottom: Market List + Execution Log */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">

--- a/src/components/EquityCurveChart.tsx
+++ b/src/components/EquityCurveChart.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine,
+  ResponsiveContainer,
+} from "recharts";
+import type { EquityPoint } from "@/lib/equityCurve";
+
+interface EquityCurveChartProps {
+  data: EquityPoint[];
+  onReset: () => void;
+}
+
+function formatTime(ts: number) {
+  return new Date(ts).toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+}
+
+export default function EquityCurveChart({ data, onReset }: EquityCurveChartProps) {
+  const chartData = data.map((d) => ({
+    ...d,
+    time: formatTime(d.timestamp),
+  }));
+
+  const hasData = chartData.length > 0;
+  const latestEquity = hasData ? chartData[chartData.length - 1].equity : null;
+
+  return (
+    <div className="border border-gray-700 rounded-sm bg-gray-900/50 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <div className="text-[10px] tracking-widest text-gray-500 uppercase">
+          EQUITY CURVE (PAPER TRADING)
+        </div>
+        <div className="flex items-center gap-3 text-[10px] text-gray-500">
+          {latestEquity !== null && (
+            <span className="tabular-nums">
+              EQUITY: {latestEquity.toFixed(2)}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={onReset}
+            className="border border-gray-700 px-2 py-0.5 rounded-sm text-[10px] uppercase tracking-widest hover:bg-gray-800 transition-colors"
+          >
+            Reset Sim
+          </button>
+        </div>
+      </div>
+      <div className="h-40">
+        {!hasData ? (
+          <div className="h-full flex items-center justify-center text-gray-600 text-sm">
+            Waiting for signals to build equity curve...
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#1f2937" />
+              <XAxis
+                dataKey="time"
+                tick={{ fill: "#6b7280", fontSize: 10 }}
+                stroke="#374151"
+              />
+              <YAxis
+                tick={{ fill: "#6b7280", fontSize: 10 }}
+                stroke="#374151"
+                tickFormatter={(v: number) => v.toFixed(0)}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: "#111827",
+                  border: "1px solid #374151",
+                  borderRadius: 2,
+                  fontFamily: "JetBrains Mono, monospace",
+                  fontSize: 11,
+                }}
+                labelStyle={{ color: "#9ca3af" }}
+                formatter={(value: number) => [value.toFixed(2), "Equity"]}
+              />
+              <ReferenceLine
+                y={10_000}
+                stroke="#4b5563"
+                strokeDasharray="4 4"
+                strokeOpacity={0.6}
+              />
+              <Line
+                type="monotone"
+                dataKey="equity"
+                stroke="#22c55e"
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 3, fill: "#22c55e" }}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+      <div className="mt-2 text-[10px] text-gray-600">
+        HYPOTHETICAL P&L — FIXED SIZE, NO FEES. NOT REAL TRADING.
+      </div>
+    </div>
+  );
+}

--- a/src/lib/equityCurve.ts
+++ b/src/lib/equityCurve.ts
@@ -1,6 +1,8 @@
 // Simple equity curve / paper trading simulation for arbitrage signals.
 // v0: fixed position size, no leverage or fees.
 
+import type { ProcessedMarket } from "./types";
+
 export type EquityPoint = {
   timestamp: number;
   equity: number;
@@ -8,8 +10,137 @@ export type EquityPoint = {
 
 export const INITIAL_EQUITY = 10_000;
 
-// TODO: implement simulation engine that consumes processed markets + signals
-// and produces an array of EquityPoint values for charting.
-export function simulateEquityCurve(): EquityPoint[] {
-  return [];
+export type PositionSide = "LONG" | "SHORT";
+
+export interface Position {
+  marketId: string;
+  side: PositionSide;
+  entryPrice: number;
+  size: number;
+  openTimestamp: number;
+  closeTimestamp?: number;
+  realizedPnl: number;
+}
+
+export interface SimulationState {
+  equity: number;
+  realizedPnl: number;
+  positions: Record<string, Position>;
+}
+
+// Fixed position size per trade (USDC notional)
+export const POSITION_SIZE = 1_000;
+
+// Open a position when divergence exceeds this threshold
+export const OPEN_THRESHOLD = 0.02; // 2%
+
+// Close when divergence normalizes below this threshold or signal flips
+export const CLOSE_THRESHOLD = 0.005; // 0.5%
+
+export function createInitialState(): SimulationState {
+  return {
+    equity: INITIAL_EQUITY,
+    realizedPnl: 0,
+    positions: {},
+  };
+}
+
+function getDirectionFromSignal(signal: ProcessedMarket["signal"]): PositionSide | null {
+  if (signal === "BUY") return "LONG";
+  if (signal === "SELL") return "SHORT";
+  return null;
+}
+
+function computeUnrealizedPnl(
+  positions: Record<string, Position>,
+  markets: ProcessedMarket[]
+): number {
+  let unrealized = 0;
+
+  for (const pos of Object.values(positions)) {
+    const market = markets.find((m) => m.id === pos.marketId);
+    if (!market) continue;
+
+    const dir = pos.side === "LONG" ? 1 : -1;
+    const priceDiff = market.midPrice - pos.entryPrice;
+    unrealized += dir * priceDiff * pos.size;
+  }
+
+  return unrealized;
+}
+
+export function stepEquitySimulation(
+  prevState: SimulationState,
+  markets: ProcessedMarket[],
+  timestamp: number
+): { state: SimulationState; point: EquityPoint } {
+  // Clone state to avoid accidental mutation
+  const state: SimulationState = {
+    equity: prevState.equity,
+    realizedPnl: prevState.realizedPnl,
+    positions: { ...prevState.positions },
+  };
+
+  // 1) Close positions when signal flips or divergence normalizes
+  for (const [marketId, pos] of Object.entries(state.positions)) {
+    const market = markets.find((m) => m.id === marketId);
+    if (!market) continue;
+
+    const dir = pos.side === "LONG" ? 1 : -1;
+    const shouldClose =
+      market.signal === "HOLD" ||
+      Math.abs(market.divergence) < CLOSE_THRESHOLD ||
+      getDirectionFromSignal(market.signal) !== pos.side;
+
+    if (shouldClose) {
+      const priceDiff = market.midPrice - pos.entryPrice;
+      const pnl = dir * priceDiff * pos.size;
+
+      state.realizedPnl += pnl;
+      state.positions[marketId] = {
+        ...pos,
+        closeTimestamp: timestamp,
+        realizedPnl: pos.realizedPnl + pnl,
+      };
+
+      // Remove closed position from active book
+      delete state.positions[marketId];
+    }
+  }
+
+  // 2) Open new positions when divergence is large and no active position
+  for (const market of markets) {
+    const side = getDirectionFromSignal(market.signal);
+    if (!side) continue;
+
+    const existing = state.positions[market.id];
+    if (existing) {
+      // Already have a position on this market; skip for v0
+      continue;
+    }
+
+    if (Math.abs(market.divergence) >= OPEN_THRESHOLD) {
+      state.positions[market.id] = {
+        marketId: market.id,
+        side,
+        entryPrice: market.midPrice,
+        size: POSITION_SIZE,
+        openTimestamp: timestamp,
+        realizedPnl: 0,
+      };
+    }
+  }
+
+  // 3) Recompute equity: initial + realized + unrealized
+  const unrealized = computeUnrealizedPnl(state.positions, markets);
+  const equity = INITIAL_EQUITY + state.realizedPnl + unrealized;
+  state.equity = equity;
+
+  return {
+    state,
+    point: {
+      timestamp,
+      equity,
+    },
+  };
 }

--- a/src/lib/equityCurve.ts
+++ b/src/lib/equityCurve.ts
@@ -1,0 +1,15 @@
+// Simple equity curve / paper trading simulation for arbitrage signals.
+// v0: fixed position size, no leverage or fees.
+
+export type EquityPoint = {
+  timestamp: number;
+  equity: number;
+};
+
+export const INITIAL_EQUITY = 10_000;
+
+// TODO: implement simulation engine that consumes processed markets + signals
+// and produces an array of EquityPoint values for charting.
+export function simulateEquityCurve(): EquityPoint[] {
+  return [];
+}


### PR DESCRIPTION
Implements issue #2 by adding a simple client-side paper trading layer and equity curve chart:

- Adds equityCurve simulation engine with fixed position sizing, open/close rules based on divergence and signal flips
- Tracks realized + unrealized P&L and exposes equity points for charting
- New EquityCurveChart (Recharts) panel below divergence chart, clearly labeled as hypothetical P&L
- Reset button to clear simulation state without reloading the app

No real trading or wallet integration; all logic is purely client-side and uses existing BUY/SELL/HOLD signals.