### PR TITLE
Add multi-asset support for BTC, ETH, and SOL

### DIFF
--- a/src/app/api/markets/route.ts
+++ b/src/app/api/markets/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { POLYMARKET_API, BINANCE_REST } from "@/lib/constants";
-import { processMarket, isBtcPriceMarket } from "@/lib/polymarket";
-import type { DashboardData } from "@/lib/types";
+import { processMarket, isSupportedAssetPriceMarket, inferAsset } from "@/lib/polymarket";
+import type { AssetPrices, DashboardData } from "@/lib/types";
 import { getLatestWsPrice, initBinanceWs } from "@/lib/binanceWs";
 
 export const dynamic = "force-dynamic";
@@ -28,7 +28,7 @@ export async function GET() {
 
     // Fetch events (contains nested markets). Prefer WebSocket BTC price but
     // fall back to REST if no WebSocket price is available yet.
-    const [eventsRes, binanceRes] = await Promise.all([
+    const [eventsRes, btcRes, ethRes, solRes] = await Promise.all([
       fetch(
         `${POLYMARKET_API.replace("/markets", "/events")}?limit=300&active=true&closed=false`,
         { next: { revalidate: 0 } }
@@ -36,25 +36,39 @@ export async function GET() {
       fetch(`${BINANCE_REST}?symbol=BTCUSDT`, {
         next: { revalidate: 0 },
       }),
+      fetch(`${BINANCE_REST}?symbol=ETHUSDT`, {
+        next: { revalidate: 0 },
+      }),
+      fetch(`${BINANCE_REST}?symbol=SOLUSDT`, {
+        next: { revalidate: 0 },
+      }),
     ]);
 
-    if (!eventsRes.ok || !binanceRes.ok) {
+    if (!eventsRes.ok || !btcRes.ok || !ethRes.ok || !solRes.ok) {
       return NextResponse.json(
         { error: "Failed to fetch upstream data" },
         { status: 502 }
       );
     }
 
-    const [eventsData, binanceData] = await Promise.all([
+    const [eventsData, btcData, ethData, solData] = await Promise.all([
       eventsRes.json(),
-      binanceRes.json(),
+      btcRes.json(),
+      ethRes.json(),
+      solRes.json(),
     ]);
 
     const wsPrice = getLatestWsPrice();
     const btcPrice =
       typeof wsPrice === "number" && !Number.isNaN(wsPrice)
         ? wsPrice
-        : parseFloat(binanceData.price);
+        : parseFloat(btcData.price);
+
+    const prices: AssetPrices = {
+      BTC: btcPrice,
+      ETH: parseFloat(ethData.price),
+      SOL: parseFloat(solData.price),
+    };
 
     // Extract all markets from events, filter for BTC price predictions
     const allMarkets: Array<{
@@ -72,7 +86,7 @@ export async function GET() {
           market.active &&
           !market.closed &&
           market.outcomePrices &&
-          isBtcPriceMarket(market.question)
+          isSupportedAssetPriceMarket(market.question)
         ) {
           allMarkets.push({
             id: String(market.id),
@@ -99,7 +113,7 @@ export async function GET() {
             m.active &&
             !m.closed &&
             m.outcomePrices &&
-            isBtcPriceMarket(m.question) &&
+            isSupportedAssetPriceMarket(m.question) &&
             !allMarkets.some((existing) => String(existing.id) === String(m.id))
           ) {
             allMarkets.push({
@@ -118,14 +132,20 @@ export async function GET() {
     }
 
     const markets = allMarkets
-      .map((m) => processMarket(m, btcPrice))
+      .map((m) => {
+        const asset = inferAsset(m.question);
+        if (!asset) return null;
+        const spot = prices[asset];
+        if (!spot || Number.isNaN(spot)) return null;
+        return processMarket(m, spot);
+      })
       .filter((m): m is NonNullable<typeof m> => m !== null)
       .sort((a, b) => Math.abs(b.divergence) - Math.abs(a.divergence));
 
     const topDivergence = markets.length > 0 ? markets[0] : null;
 
     const data: DashboardData = {
-      btcPrice,
+      prices,
       markets,
       topDivergence,
       timestamp: Date.now(),

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import ExecutionLog from "@/components/ExecutionLog";
 import EquityCurveChart from "@/components/EquityCurveChart";
 import { POLL_INTERVAL_MS, MAX_CHART_POINTS, MAX_LOG_ENTRIES } from "@/lib/constants";
 import type {
+  AssetSymbol,
   DashboardData,
   DivergencePoint,
   LogEntry,
@@ -25,6 +26,7 @@ export default function Dashboard() {
   const [chartData, setChartData] = useState<DivergencePoint[]>([]);
   const [equityData, setEquityData] = useState<EquityPoint[]>([]);
   const [simState, setSimState] = useState<SimulationState | null>(null);
+  const [selectedAsset, setSelectedAsset] = useState<AssetSymbol | "ALL">("ALL");
   const [logEntries, setLogEntries] = useState<LogEntry[]>([]);
   const [isLive, setIsLive] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -72,28 +74,34 @@ export default function Dashboard() {
 
       const dashData: DashboardData = await res.json();
       setData(dashData);
+
+      const visibleMarkets =
+        selectedAsset === "ALL"
+          ? dashData.markets
+          : dashData.markets.filter((m) => m.asset === selectedAsset);
       setIsLive(true);
       setError(null);
 
-      // Add divergence points for chart
-      if (dashData.topDivergence) {
+      // Add divergence points for chart (respect asset filter)
+      const topForChart = visibleMarkets[0] ?? dashData.topDivergence;
+      if (topForChart) {
         setChartData((prev) => {
           const next = [
             ...prev,
             {
               timestamp: dashData.timestamp,
-              label: dashData.topDivergence!.title.slice(0, 20),
-              divergence: dashData.topDivergence!.divergence,
-              btcPrice: dashData.btcPrice,
-              marketTitle: dashData.topDivergence!.title,
+              label: topForChart.title.slice(0, 20),
+              divergence: topForChart.divergence,
+              btcPrice: dashData.prices.BTC,
+              marketTitle: topForChart.title,
             },
           ];
           return next.slice(-MAX_CHART_POINTS);
         });
       }
 
-      // Generate log entries
-      const newLogs = generateLogEntries(dashData.markets, dashData.timestamp);
+      // Generate log entries (respect asset filter)
+      const newLogs = generateLogEntries(visibleMarkets, dashData.timestamp);
       if (newLogs.length > 0) {
         setLogEntries((prev) => [...prev, ...newLogs].slice(-MAX_LOG_ENTRIES));
       }
@@ -103,7 +111,7 @@ export default function Dashboard() {
         const baseState = prev ?? createInitialState();
         const { state: nextState, point } = stepEquitySimulation(
           baseState,
-          dashData.markets,
+          visibleMarkets,
           dashData.timestamp
         );
         setEquityData((prevPoints) => {
@@ -137,10 +145,29 @@ export default function Dashboard() {
 
       {/* Stats Bar */}
       <StatsBar
-        btcPrice={data?.btcPrice ?? 0}
+        prices={data?.prices ?? { BTC: 0, ETH: 0, SOL: 0 }}
         topMarket={data?.topDivergence ?? null}
         isLive={isLive}
       />
+
+      {/* Asset Filter */}
+      <div className="flex justify-end text-[10px] text-gray-500">
+        <span className="mr-2 uppercase tracking-widest">Asset:</span>
+        {["ALL", "BTC", "ETH", "SOL"].map((asset) => (
+          <button
+            key={asset}
+            type="button"
+            onClick={() => setSelectedAsset(asset as AssetSymbol | "ALL")}
+            className={`mx-1 px-2 py-0.5 border rounded-sm ${
+              selectedAsset === asset
+                ? "border-cyan-400 text-cyan-300"
+                : "border-gray-700 text-gray-500 hover:border-gray-500"
+            }`}
+          >
+            {asset}
+          </button>
+        ))}
+      </div>
 
       {/* Divergence Chart */}
       <DivergenceChart data={chartData} />

--- a/src/components/MarketList.tsx
+++ b/src/components/MarketList.tsx
@@ -24,7 +24,8 @@ export default function MarketList({ markets }: MarketListProps) {
           <table className="w-full text-xs">
             <thead>
               <tr className="text-gray-500 border-b border-gray-800">
-                <th className="text-left px-4 py-2 font-normal">MARKET</th>
+                <th className="text-left px-3 py-2 font-normal">ASSET</th>
+                <th className="text-left px-1 py-2 font-normal">MARKET</th>
                 <th className="text-right px-2 py-2 font-normal">MID</th>
                 <th className="text-right px-2 py-2 font-normal">FAIR</th>
                 <th className="text-right px-2 py-2 font-normal">DIV %</th>
@@ -55,7 +56,10 @@ export default function MarketList({ markets }: MarketListProps) {
                     transition={{ delay: i * 0.03 }}
                     className="border-b border-gray-800/50 hover:bg-gray-800/30"
                   >
-                    <td className="px-4 py-2 text-gray-300 max-w-[200px] truncate">
+                    <td className="px-3 py-2 text-gray-400 text-[10px]">
+                      {market.asset}
+                    </td>
+                    <td className="px-1 py-2 text-gray-300 max-w-[200px] truncate">
                       {market.title}
                     </td>
                     <td className="text-right px-2 py-2 text-cyan-400 tabular-nums">

--- a/src/components/StatsBar.tsx
+++ b/src/components/StatsBar.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { motion, AnimatePresence } from "framer-motion";
-import type { ProcessedMarket } from "@/lib/types";
+import type { AssetPrices, ProcessedMarket } from "@/lib/types";
 
 interface StatsBarProps {
-  btcPrice: number;
+  prices: AssetPrices;
   topMarket: ProcessedMarket | null;
   isLive: boolean;
 }
@@ -44,7 +44,7 @@ function StatCard({
   );
 }
 
-export default function StatsBar({ btcPrice, topMarket, isLive }: StatsBarProps) {
+export default function StatsBar({ prices, topMarket, isLive }: StatsBarProps) {
   const divergence = topMarket?.divergence ?? 0;
   const divergenceColor =
     Math.abs(divergence) > 0.02
@@ -81,8 +81,26 @@ export default function StatsBar({ btcPrice, topMarket, isLive }: StatsBarProps)
         <StatCard
           label="BTC / USD"
           value={
-            btcPrice > 0
-              ? `$${btcPrice.toLocaleString("en-US", { maximumFractionDigits: 0 })}`
+            prices.BTC > 0
+              ? `$${prices.BTC.toLocaleString("en-US", { maximumFractionDigits: 0 })}`
+              : "---"
+          }
+          color="text-white"
+        />
+        <StatCard
+          label="ETH / USD"
+          value={
+            prices.ETH > 0
+              ? `$${prices.ETH.toLocaleString("en-US", { maximumFractionDigits: 0 })}`
+              : "---"
+          }
+          color="text-white"
+        />
+        <StatCard
+          label="SOL / USD"
+          value={
+            prices.SOL > 0
+              ? `$${prices.SOL.toLocaleString("en-US", { maximumFractionDigits: 0 })}`
               : "---"
           }
           color="text-white"

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,6 +1,7 @@
 export const POLYMARKET_API = "https://gamma-api.polymarket.com/markets";
 export const BINANCE_REST = "https://api.binance.com/api/v3/ticker/price";
 export const BINANCE_WS = "wss://stream.binance.com:9443/ws/btcusdt@ticker";
+export const SUPPORTED_ASSETS = ["BTC", "ETH", "SOL"] as const;
 
 export const POLL_INTERVAL_MS = 5_000;
 export const DIVERGENCE_THRESHOLD = 0.001; // 0.1%

--- a/src/lib/polymarket.ts
+++ b/src/lib/polymarket.ts
@@ -1,21 +1,31 @@
-import type { ProcessedMarket } from "./types";
+import type { AssetSymbol, ProcessedMarket } from "./types";
 
 /**
- * Extract a BTC strike price from a market question.
+ * Infer asset symbol from market question.
+ */
+export function inferAsset(question: string): AssetSymbol | null {
+  if (/bitcoin|btc/i.test(question)) return "BTC";
+  if (/ether|ethereum|eth\b/i.test(question)) return "ETH";
+  if (/solana|sol\b/i.test(question)) return "SOL";
+  return null;
+}
+
+/**
+ * Extract a strike price from a market question for a given asset.
  * e.g. "Will Bitcoin hit $150k by March 31, 2026?" → 150000
- * e.g. "Will BTC exceed $150,000 by April?" → 150000
+ * e.g. "Will ETH exceed $10,000 by April?" → 10000
  */
 export function extractStrikePrice(question: string): number | null {
-  // Must mention Bitcoin or BTC
-  if (!/bitcoin|btc/i.test(question)) return null;
+  // Must mention one of the supported assets
+  if (!/(bitcoin|btc|ether|ethereum|eth\b|solana|sol\b)/i.test(question)) return null;
 
   // Match dollar amounts: $150k, $150,000, $1m, etc.
   const patterns = [
-    /\$(\d+(?:,\d{3})*(?:\.\d+)?)\s*[kK]/,         // $150k, $150K
-    /\$(\d+(?:\.\d+)?)\s*[mM]/,                      // $1m, $1M
-    /\$(\d{1,3}(?:,\d{3})+)/,                         // $150,000
+    /\$(\d+(?:,\d{3})*(?:\.\d+)?)\s*[kK]/, // $150k, $150K
+    /\$(\d+(?:\.\d+)?)\s*[mM]/, // $1m, $1M
+    /\$(\d{1,3}(?:,\d{3})+)/, // $150,000
     /\$(\d+(?:\.\d+)?)\s*(?:thousand|million|billion)/i,
-    /\$(\d{4,})/,                                      // $150000 (no commas)
+    /\$(\d{4,})/, // $150000 (no commas)
   ];
 
   for (const pattern of patterns) {
@@ -24,17 +34,21 @@ export function extractStrikePrice(question: string): number | null {
       let val = parseFloat(match[1].replace(/,/g, ""));
 
       // Handle suffixes
-      if (/[kK]/.test(question.charAt(match.index! + match[0].length - 1)) ||
-          question.slice(match.index!, match.index! + match[0].length).match(/[kK]/)) {
+      if (
+        /[kK]/.test(question.charAt(match.index! + match[0].length - 1)) ||
+        question.slice(match.index!, match.index! + match[0].length).match(/[kK]/)
+      ) {
         val *= 1000;
       }
-      if (/[mM]/.test(question.charAt(match.index! + match[0].length - 1)) ||
-          question.slice(match.index!, match.index! + match[0].length).match(/[mM]/)) {
+      if (
+        /[mM]/.test(question.charAt(match.index! + match[0].length - 1)) ||
+        question.slice(match.index!, match.index! + match[0].length).match(/[mM]/)
+      ) {
         val *= 1_000_000;
       }
 
-      // Must be a plausible BTC price (at least $10,000)
-      if (val >= 10_000) return val;
+      // Must be a plausible crypto price (at least $10 for these markets)
+      if (val >= 10) return val;
     }
   }
 
@@ -42,21 +56,21 @@ export function extractStrikePrice(question: string): number | null {
 }
 
 /**
- * Check if a market question is about BTC price
+ * Check if a market question is about a supported asset price
  */
-export function isBtcPriceMarket(question: string): boolean {
-  return /bitcoin|btc/i.test(question) && extractStrikePrice(question) !== null;
+export function isSupportedAssetPriceMarket(question: string): boolean {
+  return inferAsset(question) !== null && extractStrikePrice(question) !== null;
 }
 
 /**
- * Calculate fair probability given current BTC price, strike price, and time to expiry.
+ * Calculate fair probability given current asset price, strike price, and time to expiry.
  *
  * Uses simplified log-normal model:
- * - If BTC is already above strike → high probability, slight time risk
- * - If BTC is below strike → probability based on distance and time remaining
+ * - If spot is already above strike → high probability, slight time risk
+ * - If spot is below strike → probability based on distance and time remaining
  */
 export function calculateFairProbability(
-  btcPrice: number,
+  spotPrice: number,
   strikePrice: number,
   endDate: string
 ): number {
@@ -64,7 +78,7 @@ export function calculateFairProbability(
   const expiry = new Date(endDate).getTime();
   const daysRemaining = Math.max((expiry - now) / (1000 * 60 * 60 * 24), 0.1);
 
-  const ratio = btcPrice / strikePrice;
+  const ratio = spotPrice / strikePrice;
 
   if (ratio >= 1) {
     // BTC is already above strike
@@ -98,7 +112,7 @@ export function getSignal(divergence: number): "BUY" | "SELL" | "HOLD" {
 }
 
 /**
- * Process a raw Polymarket market with BTC price context
+ * Process a raw Polymarket market with asset price context
  */
 export function processMarket(
   market: {
@@ -109,8 +123,11 @@ export function processMarket(
     volume: number;
     endDate: string;
   },
-  btcPrice: number
+  spotPrice: number
 ): ProcessedMarket | null {
+  const asset = inferAsset(market.question);
+  if (!asset) return null;
+
   const strikePrice = extractStrikePrice(market.question);
   if (!strikePrice) return null;
 
@@ -130,7 +147,7 @@ export function processMarket(
   if (yesPrice === 0 && noPrice === 1) return null;
 
   const midPrice = yesPrice;
-  const fairPrice = calculateFairProbability(btcPrice, strikePrice, market.endDate);
+  const fairPrice = calculateFairProbability(spotPrice, strikePrice, market.endDate);
   const divergence = fairPrice - midPrice;
   const signal = getSignal(divergence);
 
@@ -138,6 +155,7 @@ export function processMarket(
     id: market.id,
     title: market.question,
     slug: market.slug,
+    asset,
     yesPrice,
     noPrice,
     midPrice,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,10 +10,13 @@ export interface PolymarketMarket {
   description: string;
 }
 
+export type AssetSymbol = "BTC" | "ETH" | "SOL";
+
 export interface ProcessedMarket {
   id: string;
   title: string;
   slug: string;
+  asset: AssetSymbol;
   yesPrice: number;
   noPrice: number;
   midPrice: number;
@@ -47,8 +50,14 @@ export interface LogEntry {
   signal: "BUY" | "SELL" | "HOLD";
 }
 
+export interface AssetPrices {
+  BTC: number;
+  ETH: number;
+  SOL: number;
+}
+
 export interface DashboardData {
-  btcPrice: number;
+  prices: AssetPrices;
   markets: ProcessedMarket[];
   topDivergence: ProcessedMarket | null;
   timestamp: number;


### PR DESCRIPTION
Implements issue #3 by extending the dashboard to support BTC, ETH, and SOL:

- Generalizes Polymarket parsing to identify BTC, ETH, and SOL price markets (, )
- Adds  field to  and introduces  in 
- Fetches spot prices for BTC, ETH, and SOL from Binance (BTC still prefers WebSocket when available)
- Uses the existing fair-probability model for all assets, keyed by their own spot prices
- Updates the API route to process markets per-asset and output a combined list
- Enhances the UI:
  - StatsBar now shows BTC/ETH/SOL spot prices
  - Market list displays an asset column
  - Adds a simple asset filter (ALL / BTC / ETH / SOL) that affects markets, logs, divergence chart, and equity curve

Layout remains close to v0; this is a minimal multi-asset extension without per-asset threshold tuning.