### PR TITLE
Clarify dashboard purpose and simplify UX copy

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -150,6 +150,21 @@ export default function Dashboard() {
         isLive={isLive}
       />
 
+      {/* About box */}
+      <div className="border border-gray-700 rounded-sm bg-gray-900/60 p-3 text-[11px] text-gray-300">
+        <div className="text-[10px] tracking-widest text-gray-500 uppercase mb-1">
+          WHAT THIS DASHBOARD DOES
+        </div>
+        <p className="mb-1">
+          We watch crypto prediction markets (BTC, ETH, SOL) on Polymarket and compare the markets
+          odds to a simple model based on current price and time left until expiry.
+        </p>
+        <p>
+          When the difference is large, we flag it as a possible mispricing and show what would have
+          happened if you traded every BUY/SELL signal with fake money. No real trades are placed.
+        </p>
+      </div>
+
       {/* Asset Filter */}
       <div className="flex justify-end text-[10px] text-gray-500">
         <span className="mr-2 uppercase tracking-widest">Asset:</span>

--- a/src/components/DivergenceChart.tsx
+++ b/src/components/DivergenceChart.tsx
@@ -34,8 +34,11 @@ export default function DivergenceChart({ data }: DivergenceChartProps) {
 
   return (
     <div className="border border-gray-700 rounded-sm bg-gray-900/50 p-4">
-      <div className="text-[10px] tracking-widest text-gray-500 uppercase mb-3">
-        DIVERGENCE CHART (%)
+      <div className="text-[10px] tracking-widest text-gray-500 uppercase mb-1">
+        MISPRICING OVER TIME (MODEL VS MARKET)
+      </div>
+      <div className="text-[10px] text-gray-600 mb-2">
+        Above 0%: our model is more bullish than the market (BUY bias). Below 0%: more bearish (SELL bias).
       </div>
       <div className="h-48">
         {chartData.length < 2 ? (
@@ -65,7 +68,10 @@ export default function DivergenceChart({ data }: DivergenceChartProps) {
                   fontSize: 11,
                 }}
                 labelStyle={{ color: "#9ca3af" }}
-                formatter={(value: number) => [`${value.toFixed(3)}%`, "Divergence"]}
+                formatter={(value: number) => [
+                  `${value.toFixed(3)}%`,
+                  "Mispricing (model - market)",
+                ]}
               />
               <ReferenceLine y={2} stroke="#22c55e" strokeDasharray="5 5" strokeOpacity={0.5} />
               <ReferenceLine y={-2} stroke="#ef4444" strokeDasharray="5 5" strokeOpacity={0.5} />

--- a/src/components/EquityCurveChart.tsx
+++ b/src/components/EquityCurveChart.tsx
@@ -39,7 +39,7 @@ export default function EquityCurveChart({ data, onReset }: EquityCurveChartProp
     <div className="border border-gray-700 rounded-sm bg-gray-900/50 p-4">
       <div className="flex items-center justify-between mb-3">
         <div className="text-[10px] tracking-widest text-gray-500 uppercase">
-          EQUITY CURVE (PAPER TRADING)
+          WHAT IF YOU TRADED EVERY SIGNAL? (FAKE P&L)
         </div>
         <div className="flex items-center gap-3 text-[10px] text-gray-500">
           {latestEquity !== null && (

--- a/src/components/ExecutionLog.tsx
+++ b/src/components/ExecutionLog.tsx
@@ -30,7 +30,7 @@ export default function ExecutionLog({ entries }: ExecutionLogProps) {
     <div className="border border-gray-700 rounded-sm bg-gray-900/50 flex flex-col min-h-0">
       <div className="px-4 py-2 border-b border-gray-700">
         <span className="text-[10px] tracking-widest text-gray-500 uppercase">
-          EXECUTION LOG
+          SIGNAL HISTORY (FAKE TRADES)
         </span>
       </div>
       <div ref={scrollRef} className="overflow-y-auto flex-1 max-h-64 font-mono">

--- a/src/components/StatsBar.tsx
+++ b/src/components/StatsBar.tsx
@@ -106,24 +106,24 @@ export default function StatsBar({ prices, topMarket, isLive }: StatsBarProps) {
           color="text-white"
         />
         <StatCard
-          label="POLY MID"
+          label="MARKET PRICE (POLY)"
           value={topMarket ? topMarket.midPrice.toFixed(2) : "---"}
           subValue={topMarket?.title.slice(0, 30) ?? ""}
           color="text-cyan-400"
         />
         <StatCard
-          label="FAIR"
+          label="MODEL PRICE (OUR ESTIMATE)"
           value={topMarket ? topMarket.fairPrice.toFixed(2) : "---"}
           color="text-purple-400"
         />
         <StatCard
-          label="DIVERGENCE"
+          label="MISPRICING (MODEL - MARKET)"
           value={
             topMarket
               ? `${divergence > 0 ? "+" : ""}${(divergence * 100).toFixed(2)}%`
               : "---"
           }
-          subValue={topMarket?.signal ?? ""}
+          subValue={topMarket ? `Signal: ${topMarket.signal}` : ""}
           color={divergenceColor}
         />
       </div>


### PR DESCRIPTION
Addresses issue #7 by making the dashboard more understandable for non-quant users.\n\nChanges\n-------\n- Adds an "About this dashboard" box under the header, explaining in plain language that we compare Polymarket odds to a simple model, and simulate P&L for following all signals (fake trading only).\n- Renames key metrics in the stats bar:\n  - "POLY MID" → "MARKET PRICE (POLY)"\n  - "FAIR" → "MODEL PRICE (OUR ESTIMATE)"\n  - "DIVERGENCE" → "MISPRICING (MODEL - MARKET)" with subtext .\n- Divergence chart:\n  - Title becomes "MISPRICING OVER TIME (MODEL VS MARKET)".\n  - Adds a short inline explanation: above 0% = model more bullish (BUY bias), below 0% = more bearish (SELL bias).\n  - Tooltip label updated to "Mispricing (model - market)".\n- Equity curve panel:\n  - Title changed to "WHAT IF YOU TRADED EVERY SIGNAL? (FAKE P&L)" to make its purpose obvious.\n- Execution log panel:\n  - Title changed to "SIGNAL HISTORY (FAKE TRADES)" to emphasize this is simulated, not real execution.\n\nNo changes were made to the trading logic or data model; this is strictly a copy/UX pass.\n\nCloses #7.