### PR TITLE
Add simple landing copy and README overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,79 @@
+# Polymarket Crypto Mispricing Dashboard
+
+A simple, read-only dashboard that watches crypto prediction questions on Polymarket and looks for odds that seem far from reality.
+
+The app:
+
+- Streams **BTC / ETH / SOL prices** from Binance.
+- Pulls **prediction questions** from Polymarket (e.g. "Will Bitcoin hit $150k by December 2026?").
+- Compares **market odds** (the Polymarket price between 0 and 1) to a **simple model** that looks at current price and time left.
+- Highlights **possible mispricings** when the gap is big.
+- Draws a **fake P&L line** showing what would have happened if you followed every BUY / SELL signal with paper money.
+
+No real trades. No keys. Just a visual way to explore when prediction markets might be out of line with a basic model.
+
+## Who this is for
+
+- People who are **curious about prediction markets** and want to see concrete examples.
+- **Crypto / DeFi hobbyists** who like spotting weird or extreme market odds.
+- Learners who prefer to **see a pretend P&L** instead of risking real money.
+
+It is **not** a live trading tool, and it does not connect to wallets or execute orders.
+
+## How to read the dashboard
+
+At a high level:
+
+1. **Stats bar (top)**
+   - Shows BTC / ETH / SOL prices.
+   - Shows a single "top" market with the biggest mispricing:
+     - **Market Price (Poly)** – current Polymarket price for YES.
+     - **Model Price (Our Estimate)** – our rough probability.
+     - **Mispricing (Model − Market)** – if positive, model is more bullish; if negative, more bearish.
+
+2. **Mispricing chart**
+   - A line over time of how big the mispricing is for the most interesting market (or filtered asset).
+   - Above 0%: model is more bullish than the market (BUY bias).
+   - Below 0%: model is more bearish than the market (SELL bias).
+
+3. **"What if you traded every signal?" (fake P&L)**
+   - Starts at 10,000 USDC (paper money).
+   - Each time there is a strong BUY / SELL signal, the sim opens a fixed-size position.
+   - When the mispricing normalizes or flips, the position is closed and the line moves up or down.
+   - This is **only a simulation** – it shows how a very simple strategy might have behaved.
+
+4. **Market list + signal history**
+   - **Market list**: all tracked questions, with asset, market text, market price, model price, mispricing %, and suggested signal.
+   - **Signal history (fake trades)**: a scrolling log of the signals the sim would have taken.
+
+## Quick example
+
+Imagine a Polymarket question:
+
+> "Will Bitcoin hit $150k by December 31 this year?"
+
+- Polymarket price is **0.60** → crowd says ~60% chance YES.
+- Our model thinks the chance is closer to **0.20** based on current BTC price and time left.
+
+On the dashboard you would see something like:
+
+- Market Price (Poly): `0.60`
+- Model Price (Our Estimate): `0.20`
+- Mispricing (Model − Market): `−40%`
+- Signal: `SELL`
+
+In plain English:
+
+> The crowd looks much more optimistic than our simple math. If you followed the strategy, you would *sell* this market, expecting its price to come down later.
+
+If the price later drops from 0.60 to 0.30, the fake P&L line will move up to show that this bet would have made money in the simulation.
+
+## Running locally
+
+```bash
+npm install
+npm run dev
+# then open http://localhost:3000
+```
+
+You do not need any API keys: both Polymarket and Binance data are fetched from public endpoints.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -151,18 +151,33 @@ export default function Dashboard() {
       />
 
       {/* About box */}
-      <div className="border border-gray-700 rounded-sm bg-gray-900/60 p-3 text-[11px] text-gray-300">
+      <div className="border border-gray-700 rounded-sm bg-gray-900/60 p-3 text-[11px] text-gray-300 space-y-1">
         <div className="text-[10px] tracking-widest text-gray-500 uppercase mb-1">
           WHAT THIS DASHBOARD DOES
         </div>
-        <p className="mb-1">
-          We watch crypto prediction markets (BTC, ETH, SOL) on Polymarket and compare the markets
-          odds to a simple model based on current price and time left until expiry.
+        <p>
+          This page watches crypto prediction questions on Polymarket (BTC, ETH, SOL) and compares
+          the crowd&apos;s odds to a simple model that looks at the current price and time left.
         </p>
         <p>
-          When the difference is large, we flag it as a possible mispricing and show what would have
-          happened if you traded every BUY/SELL signal with fake money. No real trades are placed.
+          When the gap is big, we treat it as a possible mispricing and show what would have
+          happened if you followed every BUY / SELL signal with fake money. No real trades are
+          placed.
         </p>
+        <div className="mt-2 grid gap-1 md:grid-cols-3 text-[10px] text-gray-400">
+          <div>
+            <span className="font-semibold text-gray-300">See strange markets.</span> Find
+            questions where the odds look far from what simple math suggests.
+          </div>
+          <div>
+            <span className="font-semibold text-gray-300">Learn safely.</span> Watch a pretend
+            P&amp;L line instead of risking real money.
+          </div>
+          <div>
+            <span className="font-semibold text-gray-300">For curious users.</span> Built for
+            people exploring prediction markets and crypto odds, not for live trading.
+          </div>
+        </div>
       </div>
 
       {/* Asset Filter */}


### PR DESCRIPTION
Adds a non-jargony description both on the main page and in the repo README, so new users can quickly understand what the dashboard does and who it is for.\n\nWebsite changes\n----------------\n- Expands the "About this dashboard" box under the header into a clearer landing-style block:\n  - Explains that we watch BTC/ETH/SOL prediction questions on Polymarket and compare crowd odds to a simple price+time model.\n  - States explicitly that we highlight big gaps as possible mispricings and simulate what would have happened if you followed every BUY/SELL signal with fake money (no real trades).\n  - Adds three short bullets: "See strange markets", "Learn safely", "For curious users" to describe the value and audience in plain English.\n\nREADME\n------\n- Introduces the project as a Polymarket crypto mispricing dashboard in simple language.\n- Describes who it is for and who it is not for.\n- Explains how to read each part of the dashboard (stats bar, mispricing chart, fake P&L, market list, signal history).\n- Includes a concrete example of a mispriced BTC market and what the signal means in normal English.\n- Documents basic local run instructions.\n\nNo logic or API changes; this is purely docs/copy for clarity.